### PR TITLE
v1.11 hotfix for Aplite

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -45,7 +45,7 @@
     "shortName": "Splatime Monitor",
     "uuid": "0b4c1dc4-a1d3-446a-b239-378c43089c01",
     "versionCode": 1,
-    "versionLabel": "1.1",
+    "versionLabel": "1.11",
     "watchapp": {
         "hiddenApp": false,
         "watchface": false

--- a/src/app.js
+++ b/src/app.js
@@ -20,12 +20,13 @@ var RULES_SIZE = new Vector2(144, 34);
 var MAPS_POSITION = new Vector2(0, 104);
 var MAPS_SIZE = new Vector2(144, 44);
 
-var platform = Pebble.getActiveWatchInfo().platform;
-if (platform == "basalt") {
-    console.log("Detected basalt platform: " + Pebble.getActiveWatchInfo().platform);
+var platform = null;
+if (Pebble.getActiveWatchInfo) {
+    console.log("Detected Basalt platform");
+    platform = "basalt";
 }
 else {
-    console.log("Detected aplite platform: " + Pebble.getActiveWatchInfo().platform);
+    console.log("Detected Aplite platform");
 }
 
 var scheduledMaps = function() {


### PR DESCRIPTION
Changed the usage of Pebble.getActiveWatchInfo to avoid app crashes on Aplite.
